### PR TITLE
Fix in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyYAML==3.10
 anyjson==0.3.3
 beanstalkc==0.2.0
 boto==2.5.2
-tweepy=1.12
+tweepy==1.12
 wsgiref==0.1.2
 Logbook==0.3
 requests==0.14.0


### PR DESCRIPTION
With the missing = sign the command
pip install -r requirements.txt 
failed with the following message:

ValueError: ('Expected version spec in', 'tweepy=1.12', 'at', '=1.12')
